### PR TITLE
fix: remove duplicate highlightedHtml property (merge artifact)

### DIFF
--- a/testapi-Service/frontend/src/app/interface-test-api/gherkin-editor/gherkin-editor.component.ts
+++ b/testapi-Service/frontend/src/app/interface-test-api/gherkin-editor/gherkin-editor.component.ts
@@ -22,7 +22,6 @@ export class GherkinEditorComponent implements OnInit, AfterViewChecked {
   parsedTests: TestModel2[] = [];
   parseErrors: string[] = [];
   showPreview: boolean = false;
-  highlightedHtml: string = '';
   private needsSync = false;
 
   constructor(private gherkinParser: GherkinParserService) {}


### PR DESCRIPTION
## Résumé

Suppression d'une ligne `highlightedHtml: string = ''` en double dans `gherkin-editor.component.ts`, introduite lors de la résolution automatique du merge.

Cette duplication provoque une erreur de compilation TypeScript (`TS2300: Duplicate identifier`) qui empêche le build du frontend.

**Fichier modifié :** `testapi-Service/frontend/src/app/interface-test-api/gherkin-editor/gherkin-editor.component.ts`
**Changement :** 1 ligne supprimée

🤖 Generated with [Claude Code](https://claude.com/claude-code)